### PR TITLE
build: Used deploy stage to publish release only on git tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,11 @@ before_install:
     fi
 
 script:
-  - npm test --silent
+  - npm test --silent 
 
-after_script:
-- |
-  echo ">>> Publish"
-  npm run vscode:publish
-
-stages:
-- name: after_script
-  if: env(TRAVIS_TAG) =~ ^v
+deploy:
+  provider: script
+  script: "npm run vscode:publish"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
## Context

The purpose of this PR is to prevent builds that are invoked by a git tag do not attempt to release a new version of the extension. Using the ruby conditional logic provided in the VSCode docs is outdated due to recent changes in Travis. Instead, the dedicated `deploy` stage will be used which is more reliable. 

## Steps to Test
1. Watch the travis PR build 
2. Verify that the build finishes successfully and the deploy stage is skipped 

