### PR TITLE
fix: Improved performance when printing logs in Output Channel

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|package-lock.json",
     "lines": null
   },
-  "generated_at": "2022-01-12T18:12:20Z",
+  "generated_at": "2022-04-05T14:36:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,8 +76,19 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
-  "version": "0.13.1+ibm.46.dss",
+  "results": {
+    "ci/Dockerfile": [
+      {
+        "hashed_secret": "b991a3507ae53155dfb37a8c817f74f847d66043",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 56,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,6 @@ node_js: node
 os:
   - linux
 
-before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y;
-      sudo apt-get update -q;
-      sudo apt-get install libstdc++-4.9-dev -y;
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
-
-script:
-  - npm test --silent 
-
 deploy:
   provider: script
   script: "npm run vscode:publish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 sudo: false
 
+services:
+  - docker
+
 language: node_js
 
 node_js: node
 
 os:
   - linux
+
+script:
+  docker build -t vscode-linux-build-agent -f ci/Dockerfile .;
+  docker run vscode-linux-build-agent /bin/sh -c 'xvfb-run -a -l --server-args=":99 -screen 0 1024x786x24" npm test';
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ os:
   - linux
 
 script:
-  docker build -t vscode-linux-build-agent -f ci/Dockerfile .;
-  docker run vscode-linux-build-agent /bin/sh -c 'xvfb-run -a -l --server-args=":99 -screen 0 1024x786x24" npm test';
+  docker build -t vscode-build -f ci/Dockerfile .;
+  docker run vscode-build /bin/sh -c 'xvfb-run -a -l --server-args=":99 -screen 0 1024x786x24" npm test';
 
 deploy:
   provider: script

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 out/test/**
 test/**
+ci/**
 src/**
 **/*.map
 .gitignore

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This extension provides capabilities for the [IBM Cloud CLI](https://cloud.ibm.c
 ## Changelog
 - v0.0.16
   - Improved performance when displaying CLI logs in Output Channel
+  - Used correct command ext identifier when calling cf logs commands
 - *v0.0.15*
   - Updated to IBM Cloud 2.6.0
   - Rebranded extension to IBM Cloud CLI

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 This extension provides capabilities for the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/index.html) from directly within the VS Code editor. Use the VS Code command palette to quickly access all `ibmcloud dev` commands, without the need to leave the editor's context.
 
 ## Changelog
+- v0.0.16
+  - Improved performance when displaying CLI logs in Output Channel
 - *v0.0.15*
   - Updated to IBM Cloud 2.6.0
   - Rebranded extension to IBM Cloud CLI

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,83 @@
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN groupadd --gid 1000 builduser \
+  && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser \
+  && mkdir -p /setup
+
+# Set up TEMP directory
+ENV TEMP=/tmp
+RUN chmod a+rwx /tmp
+
+# Latest stable git
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:git-core/ppa -y
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    git \
+    gnome-keyring \
+    iproute2 \
+    libfuse2 \
+    libgconf-2-4 \
+    libgdk-pixbuf2.0-0 \
+    libgl1 \
+    libgtk-3.0 \
+    libsecret-1-dev \
+    libssl-dev \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxkbfile-dev \
+    locales \
+    lsb-release \
+    lsof \
+    dbus \
+    python-dbus \
+    python-pip \
+    sudo \
+    wget \
+    xvfb \
+    tzdata \
+    unzip \
+  && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
+  && chmod +x /setup/install-build-deps.sh \
+  && bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --no-arm --no-nacl \
+  && rm -rf /var/lib/apt/lists/*
+
+# Yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install -y yarn
+
+# No Sudo Prompt
+RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
+  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+
+# Dotnet
+RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN apt-get update && apt-get install -y dotnet-sdk-2.1
+
+# Node
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get install -y nodejs 
+
+# Set python3 as default
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN python --version
+
+# Setup dbus path
+RUN mkdir -p /var/run/dbus
+COPY --chown=builduser:builduser ci/entrypoint.sh /etc/init.d/dbus-session
+RUN chmod +x /etc/init.d/dbus-session
+
+USER builduser
+WORKDIR /home/builduser
+RUN sudo chown builduser:builduser -R /var/run/dbus/
+
+COPY --chown=builduser:builduser . .
+
+ENTRYPOINT ["/etc/init.d/dbus-session"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM registry.access.redhat.com/ubi8/ubi:8.5-236.1648460182
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,74 +10,68 @@ RUN groupadd --gid 1000 builduser \
 ENV TEMP=/tmp
 RUN chmod a+rwx /tmp
 
-# Latest stable git
-RUN apt-get update && apt-get install -y software-properties-common
-RUN add-apt-repository ppa:git-core/ppa -y
-
-RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
+# Install packages needed to run vscode headless
+RUN yum update -q && yum install -y \
+    yum-utils \
     git \
-    gnome-keyring \
-    iproute2 \
-    libfuse2 \
-    libgconf-2-4 \
-    libgdk-pixbuf2.0-0 \
-    libgl1 \
-    libgtk-3.0 \
-    libsecret-1-dev \
-    libssl-dev \
-    libx11-dev \
-    libx11-xcb-dev \
-    libxkbfile-dev \
-    locales \
-    lsb-release \
+    iproute \
+    fuse\
+    vim \
+    gdk-pixbuf2 \
+    glibc-devel \
+    gtk3\
+    alsa-lib\
+    libsecret \
+    openssl-devel \
+    libX11-devel \
+    libXScrnSaver \
+    mesa-libgbm\
+    nss\
+    at-spi2-atk\
+    libX11-xcb \
     lsof \
-    dbus \
-    python-dbus \
-    python-pip \
+    python3-pip \
     sudo \
     wget \
-    xvfb \
-    tzdata \
-    unzip \
-  && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
-  && chmod +x /setup/install-build-deps.sh \
-  && bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --no-arm --no-nacl \
-  && rm -rf /var/lib/apt/lists/*
+    unzip 
 
-# Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
+# Add centos8 to mirrorlist 
+RUN yum-config-manager --add-repo https://vault.centos.org/centos/8/AppStream/x86_64/os
+
+# Downloand and import CentOS8 GPG keys
+RUN wget "https://centos.org/keys/RPM-GPG-KEY-CentOS-Official" \
+  && rpm --import RPM-GPG-KEY-CentOS-Official
 
 # No Sudo Prompt
-RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
-  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser  \
+ && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 
-# Dotnet
-RUN wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN apt-get update && apt-get install -y dotnet-sdk-2.1
+# Install Xvfb
+RUN yum install xorg-x11-server-Xvfb -y
 
 # Node
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get update && apt-get install -y nodejs 
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
+RUN yum install -y nodejs
 
 # Set python3 as default
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN python --version
+RUN alternatives --set python /usr/bin/python3
 
-# Setup dbus path
-RUN mkdir -p /var/run/dbus
+# Setup dbus path and config
+RUN rm -rf /var/run/dbus && mkdir -p /var/run/dbus
+COPY ci/dbus-policy.conf /etc/dbus-1/system.d/
+
+# Copy entrypoint dbus-dameon script
 COPY --chown=builduser:builduser ci/entrypoint.sh /etc/init.d/dbus-session
 RUN chmod +x /etc/init.d/dbus-session
 
+# Allow acccess to dbus socket for builduser
+RUN chown builduser:builduser -R /var/run/dbus/
+ENV DBUS_SESSION_BUS_ADDRESS="unix:path=/var/run/dbus/system_bus_socket"
+ENV DISPLAY :99.0
+
+COPY --chown=builduser:builduser . /home/builduser/
+
 USER builduser
 WORKDIR /home/builduser
-RUN sudo chown builduser:builduser -R /var/run/dbus/
-
-COPY --chown=builduser:builduser . .
 
 ENTRYPOINT ["/etc/init.d/dbus-session"]

--- a/ci/dbus-policy.conf
+++ b/ci/dbus-policy.conf
@@ -1,0 +1,119 @@
+<!-- This configuration file controls the systemwide message bus.
+     Add a system-local.conf and edit that rather than changing this 
+     file directly. -->
+
+<!-- Note that there are any number of ways you can hose yourself
+     security-wise by screwing up this file; in particular, you
+     probably don't want to listen on any more addresses, add any more
+     auth mechanisms, run as a different user, etc. -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- Our well-known bus type, do not change this -->
+  <type>system</type>
+
+  <!-- Run as special user -->
+  <user>dbus</user>
+
+  <!-- Fork into daemon mode -->
+  <fork/>
+
+  <!-- We use system service launching using a helper -->
+  <standard_system_servicedirs/>
+
+  <!-- This is a setuid helper that is used to launch system services -->
+  <servicehelper>/usr/lib/dbus-1.0/dbus-daemon-launch-helper</servicehelper>
+
+  <!-- Write a pid file -->
+  <pidfile>/var/run/dbus/pid</pidfile>
+
+  <!-- Enable logging to syslog -->
+  <syslog/>
+
+  <!-- Only allow socket-credentials-based authentication -->
+  <auth>EXTERNAL</auth>
+
+  <!-- Only listen on a local socket. (abstract=/path/to/socket 
+       means use abstract namespace, don't really create filesystem 
+       file; only Linux supports this. Use path=/whatever on other 
+       systems.) -->
+  <listen>unix:path=/var/run/dbus/system_bus_socket</listen>
+
+  <policy context="default">
+    <!-- All users can connect to system bus -->
+    <allow user="*"/>
+
+    <!-- Holes must be punched in service configuration files for
+         name ownership and sending method calls -->
+    <deny own="*"/>
+    <deny send_type="method_call"/>
+
+    <!-- Signals and reply messages (method returns, errors) are allowed
+         by default -->
+    <allow send_type="signal"/>
+    <allow send_requested_reply="true" send_type="method_return"/>
+    <allow send_requested_reply="true" send_type="error"/>
+
+    <!-- All messages may be received by default -->
+    <allow receive_type="method_call"/>
+    <allow receive_type="method_return"/>
+    <allow receive_type="error"/>
+    <allow receive_type="signal"/>
+
+    <!-- Allow anyone to talk to the message bus -->
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus" />
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Properties"/>
+    <!-- But disallow some specific bus services -->
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus"
+          send_member="UpdateActivationEnvironment"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus.Debug.Stats"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+  <!-- Only systemd, which runs as root, may report activation failures. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+  <!-- root may monitor the system bus. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Monitoring"/>
+  </policy>
+
+  <!-- If the Stats interface was enabled at compile-time, root may use it.
+       Copy this into system.local.conf or system.d/*.conf if you want to
+       enable other privileged users to view statistics and debug info -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Debug.Stats"/>
+  </policy>
+
+  <!-- Include legacy configuration that was preserved in a Debian upgrade,
+       if any -->
+  <include ignore_missing="yes">/etc/dbus-1/system.conf.dpkg-bak</include>
+
+  <!-- The defaults for these limits are hard-coded in dbus-daemon.
+       Some clarifications:
+       Times are in milliseconds (ms); 1000ms = 1 second
+       133169152 bytes = 127 MiB
+       33554432 bytes = 32 MiB
+       150000ms = 2.5 minutes -->
+
+  <!-- Config files are placed here that among other things, punch 
+       holes in the above policy for specific services. -->
+
+
+  <include if_selinux_enabled="yes" selinux_root_relative="yes">contexts/dbus_contexts</include>
+
+</busconfig>

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-export DBUS_SESSION_BUS_ADDRESS=$(dbus-daemon --config-file=/usr/share/dbus-1/system.conf --print-address)
+if [[ ! -f /var/run/dbus/system_bus_socket ]]; then
+  export DISPLAY=:99.0
+  dbus-daemon --config-file /etc/dbus-1/system.d/dbus-policy.conf &
+fi
 
 exec "$@"

--- a/ci/entrypoint.sh
+++ b/ci/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export DBUS_SESSION_BUS_ADDRESS=$(dbus-daemon --config-file=/usr/share/dbus-1/system.conf --print-address)
+
+exec "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-developer",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,9 +17,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "@types/node": {
@@ -27,6 +27,24 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
       "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
       "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
+      "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+      "dev": true
+    },
+    "@vscode/test-electron": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
+      "integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      }
     },
     "agent-base": {
       "version": "6.0.2",
@@ -38,9 +56,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -268,6 +286,22 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -307,6 +341,12 @@
           }
         }
       }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -362,12 +402,6 @@
         }
       }
     },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
     "buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -382,10 +416,16 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+    "buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builtin-modules": {
@@ -418,6 +458,15 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -855,21 +904,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1192,6 +1226,58 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1661,9 +1747,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -1688,9 +1774,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -1969,6 +2055,12 @@
       "requires": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true
     },
     "lodash": {
       "version": "1.0.2",
@@ -3007,6 +3099,12 @@
         }
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3210,24 +3308,6 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "source-map-url": {
@@ -3587,6 +3667,12 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
@@ -3718,9 +3804,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "uc.micro": {
@@ -3823,6 +3909,71 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
+        }
+      }
+    },
+    "unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -4080,167 +4231,6 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "vscode": {
-      "version": "1.1.37",
-      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
-      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.2",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "mocha": "^5.2.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "vscode-test": "^0.4.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "growl": {
-          "version": "1.10.5",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mocha": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.1",
-            "commander": "2.15.1",
-            "debug": "3.1.0",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.5",
-            "he": "1.1.1",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "supports-color": "5.4.0"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "vscode-test": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ibm-developer",
   "displayName": "IBM Cloud CLI",
-  "description": "Extension for VS Code editor to enable IBM Cloud CLI `ibmcloud dev` CLI capabilities from within the editing environment.",
-  "version": "0.0.15",
+  "description": "Extension for VS Code editor to enable IBM Cloud CLI capabilities from within the editing environment.",
+  "version": "0.0.16",
   "publisher": "IBM",
   "license": "Apache 2.0 (see LICENSE.txt)",
   "bugs": {
@@ -15,7 +15,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "vscode": "^1.10.0",
+    "vscode": "^1.64.0",
     "node": ">=14.0.1 <14.6.0"
   },
   "categories": [
@@ -251,28 +251,28 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "npm run vscode:prepublish",
-    "test": "node ./node_modules/vscode/bin/test",
+    "test": "node ./out/test/runTest.js",
     "tslint": "gulp tslint",
     "vscode:publish": "vsce publish"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.32",
+    "@types/mocha": "^9.1.0",
     "@types/node": "^14.0.1",
+    "@types/vscode": "^1.64.0",
+    "@vscode/test-electron": "^2.1.3",
     "gulp": "^3.9.1",
     "gulp-tslint": "^8.0.0",
     "mocha": "^5.0.2",
     "pre-commit": "^1.2.2",
     "tslint": "^5.0.0",
-    "typescript": "^2.0.3",
-    "vscode": "^1.1.37"
+    "typescript": "^4.5.5"
   },
   "dependencies": {
-    "vsce": "^2.7.0",
     "js-yaml": "^3.13.1",
     "ps-tree": "^1.1.0",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "vsce": "^2.7.0"
   },
   "pre-commit": [
     "tslint",

--- a/src/cloudfoundry/LogsCommandManager.ts
+++ b/src/cloudfoundry/LogsCommandManager.ts
@@ -31,7 +31,7 @@ export class LogsCommandManager {
     private activeLogs: Object = {};
 
     /*
-     * Register teh log start/stop commands
+     * Register the log start/stop commands
      * @param {ExtensionContext} the extension's context
      * @param {key} the event/key for the command
      */
@@ -42,9 +42,9 @@ export class LogsCommandManager {
         }
 
         const disposable = commands.registerCommand(key, () => {
-            if (key === 'extension.bx.cf.logs') {
+            if (key === 'extension.ibmcloud.cf.logs') {
                 LogsCommandManager.instance.startLogs();
-            } else if (key === 'extension.bx.cf.logs-stop') {
+            } else if (key === 'extension.ibmcloud.cf.logs-stop') {
                 LogsCommandManager.instance.stopLogs();
             }
         });
@@ -58,7 +58,7 @@ export class LogsCommandManager {
      */
     getOutputChannel(key): OutputChannel {
         if (this.outputChannels[key] === undefined) {
-            this.outputChannels[key] = window.createOutputChannel(`Bluemix: CloudFoundry: ${key}`);
+            this.outputChannels[key] = window.createOutputChannel(`IBMCloud: CloudFoundry: ${key}`);
         }
         return this.outputChannels[key];
     }
@@ -73,7 +73,7 @@ export class LogsCommandManager {
             const outputChannel = self.getOutputChannel(val);
 
             // todo: check if already active
-            const command = new SystemCommand('bx', ['cf', 'logs', val], outputChannel);
+            const command = new SystemCommand('ibmcloud', ['cf', 'logs', val], outputChannel);
             command.executeWithOutputChannel();
 
             self.activeLogs[val] = command;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,8 +46,8 @@ export function activate(context: ExtensionContext) {
 
     // IBM Cloud DEV commands *************************************
     registerCommand(context, 'extension.ibmcloud.dev.list', {cmd: 'ibmcloud', args: ['dev', 'list', '--caller-vscode']}, outputChannel, true);
-    registerCommand(context, 'extension.ibmcloud.dev.build', {cmd: 'ibmcloud', args: ['dev', 'build', '--caller-vscode', '--debug']}, outputChannel, true);
-    registerCommand(context, 'extension.ibmcloud.dev.build.release', {cmd: 'ibmcloud', args: ['dev', 'build', '--caller-vscode']}, outputChannel, true);
+    registerCommand(context, 'extension.ibmcloud.dev.build', {cmd: 'ibmcloud', args: ['dev', 'build', '--caller-vscode', '--debug']}, outputChannel, false);
+    registerCommand(context, 'extension.ibmcloud.dev.build.release', {cmd: 'ibmcloud', args: ['dev', 'build', '--caller-vscode']}, outputChannel, false);
     registerCommand(context, 'extension.ibmcloud.dev.debug', {cmd: 'ibmcloud', args: ['dev', 'debug', '--caller-vscode']}, outputChannel);
     registerCommand(context, 'extension.ibmcloud.dev.deploy', {cmd: 'ibmcloud', args: ['dev', 'deploy', '--caller-vscode', '--trace']}, outputChannel, false, DeployCommand);
     registerCommand(context, 'extension.ibmcloud.dev.diag', {cmd: 'ibmcloud', args: ['dev', 'diag', '--caller-vscode', '--trace']}, outputChannel, true);
@@ -141,7 +141,7 @@ function executeCommand(command: SystemCommand) {
  */
 function checkVersions(): Promise<any> {
 
-    return new Promise<any>((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
 
         // only run this once per session of vscode
         if (checkedVersions !== true) {

--- a/src/util/SystemCommand.ts
+++ b/src/util/SystemCommand.ts
@@ -61,7 +61,7 @@ export class SystemCommand {
         this.outputChannel = _outputChannel;
         this.sanitizeOutput = sanitizeOutput;
 
-        if (this.outputChannel !== undefined) {
+        if (this.outputChannel) {
             // NOTE: Do not perserve focus (`preserveFocus`) when showing output channel to allow 
             // other UI components a chance to be in focus such as window.showInputBox and window.showQuickPick
             this.outputChannel.show(true);
@@ -73,7 +73,7 @@ export class SystemCommand {
      * @returns {boolean} Returns active status
      */
     isActive() {
-        return (this.command !== undefined);
+        return !!this.command;
     }
 
     /*
@@ -132,13 +132,10 @@ export class SystemCommand {
 
             const opt:any = {
                 cwd: workspace.rootPath,
+                env: {
+                    ...process.env, IBMCLOUD_COLOR: false
+                }
             };
-
-            // NOTE: Currently there is an issue where the ANIS escape color sequences are not rendered correctly on Macs
-            // Until a solution is found color will be disabled on output for users running on Darwin
-            if (process.platform === 'darwin') {
-              opt.env = { ...process.env, IBMCLOUD_COLOR: false };
-            }
 
             this.invocation = spawn(this.command, this.args, opt);
 
@@ -281,7 +278,7 @@ export class SystemCommand {
      * Display output in targeted output channel
      */
     output(data: any) {
-        if (this.outputChannel !== undefined) {
+        if (this.outputChannel) {
             this.outputChannel.append(data);
         }
     }
@@ -290,7 +287,7 @@ export class SystemCommand {
      * Kill the process (spawned process only)
      */
     kill() {
-        if (this.invocation !== undefined) {
+        if (this.invocation) {
             const self = this;
             const  signal = 'SIGKILL';
             psTree(self.invocation.pid, function (err, children) {
@@ -309,7 +306,7 @@ export class SystemCommand {
                 });
             });
 
-            if (this.outputChannel !== undefined) {
+            if (this.outputChannel) {
                 this.outputChannel.show();
             }
         }

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,25 +14,32 @@
  * limitations under the License.
  **/
 
-//
-// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
-//
-// This file is providing the test runner to use when running extension tests.
-// By default the test runner in use is Mocha based.
-//
-// You can provide your own test runner if you want to override it by exporting
-// a function run(testRoot: string, clb: (error:Error) => void) that the extension
-// host can call to run the tests. The test runner is expected to use console.log
-// to report the results back to the caller. When the tests are finished, return
-// a possible error to the callback or null if none.
+import * as glob from 'glob';
+import * as Mocha from 'mocha';
+import * as path from 'path';
 
-let testRunner = require('vscode/lib/testrunner');
+export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
+    // Create the mocha test
+    const mocha = new Mocha({
+        ui: 'tdd',
+    });
 
-// You can directly control Mocha options by uncommenting the following lines
-// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
-testRunner.configure({
-    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    useColors: true,  // colored output from test results
-});
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+        if (err) {
+            return cb(err);
+        }
 
-module.exports = testRunner;
+        // Add files to the test suite
+        files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
+
+        try {
+            // Run the mocha test
+            mocha.run((failures) => {
+                cb(null, failures);
+            });
+        } catch (err) {
+            console.error(err);
+            cb(err);
+        }
+    });
+}

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -29,7 +29,6 @@ async function go() {
             extensionTestsPath,
             launchArgs: [
                 // This disables hardware acceleration that may cause problems in build
-                '--no-sandbox',
                 '--disable-gpu',
                 // This disables all extensions except the one being testing
                 '--disable-extensions',

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -29,6 +29,7 @@ async function go() {
             extensionTestsPath,
             launchArgs: [
                 // This disables hardware acceleration that may cause problems in build
+                '--no-sandbox',
                 '--disable-gpu',
                 // This disables all extensions except the one being testing
                 '--disable-extensions',

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright IBM Corporation 2016, 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+import * as path from 'path';
+
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
+
+async function go() {
+    try {
+        const extensionDevelopmentPath = path.resolve(__dirname, '../..');
+        const extensionTestsPath = path.resolve(__dirname, './');
+
+        const vscodeExecutablePath = await downloadAndUnzipVSCode();
+        await runTests({
+            vscodeExecutablePath,
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            launchArgs: [
+                // This disables hardware acceleration that may cause problems in build
+                '--disable-gpu',
+                // This disables all extensions except the one being testing
+                '--disable-extensions',
+            ],
+        });
+    } catch (err) {
+        console.error(err);
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
+}
+
+go();


### PR DESCRIPTION
# Description

When running a dev command through the VSCode command palette it takes longer than usual for the logs to appear in the Output panel. This PR solves this problem by upgrading the `vscode` npm package to 1.64 which fixes the buffering issues that occurs in the Output Channel.

# Callouts
- The `typescript` and `mocha` npm package were upgraded due to the upgrade to the `vscode` package
- There were some conditional logic changes to better ensure the Output Channel logs would appear (eg. `if(outputChannel !== undefined)` -> `if(outputChannel)`)
- As of now, colors are not suppored in the output channel so colors have been diabled in all platforms. See git issue [vscode#141556](https://github.com/microsoft/vscode/issues/141556) for more information.
- Updated travis build to run unit tests under docker 
- Used redhat ubi images to build base image for running vscode using xvfb (emulated X server)

# Steps to Reproduce
1. Download the latest version of the IBM Cloud CLI extension if not already
2. Open the Command Palette (Ctrl-Shift-P or F1) and enter the command ibmcloud dev build
3. Verify that it takes longer than a minute for the entire logs to appear in the Ouput Channel

# Solution
1. Prune any containers and images that was built in the **Steps to Reproduce** section
2. Install `vsce` npm package if not already: `npm install -g vsce`
3. Checkout PR branch
4. Run the command `vsce package`
5. Verify vsix package is built successfully
6. Open a starterkit project using VSCode
7. Go to **Extension -> Install From VSIX`** and select vsix file created in step 4
![2022-04-01_15-18](https://user-images.githubusercontent.com/5360960/161335625-a380db81-a8ff-4b7d-8567-d6e62d3b715e.png)
8. Reload VSCode when requested
9. Run `ibmcloud dev build` from Command Palette
10. Verify that performance for logs to appear have improved
