### PR TITLE
feat: Added plugin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 This extension provides capabilities for the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/index.html) from directly within the VS Code editor. Use the VS Code command palette to quickly access all `ibmcloud dev` commands, without the need to leave the editor's context.
 
 ## Changelog
+- v0.2.0
+  - Added plugin commands (install, uninstall, update)
 - v0.1.0
   - Added basic account commands (list, show, users)
   - Added view api endpoint command

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
     "onCommand:extension.ibmcloud.account.show",
     "onCommand:extension.ibmcloud.account.users",
     "onCommand:extension.ibmcloud.resource.service-instances",
-    "onCommand:extension.ibmcloud.plugin.install"
+    "onCommand:extension.ibmcloud.plugin.install",
+    "onCommand:extension.ibmcloud.plugin.uninstall",
+    "onCommand:extension.ibmcloud.plugin.update"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -284,6 +286,14 @@
       {
         "command": "extension.ibmcloud.plugin.install",
         "title": "ibmcloud plugin install"
+      },
+      {
+        "command": "extension.ibmcloud.plugin.uninstall",
+        "title": "ibmcloud plugin uninstall"
+      },
+      {
+        "command": "extension.ibmcloud.plugin.update",
+        "title": "ibmcloud plugin update"
       }
     ]
   },
@@ -334,7 +344,7 @@
   "ibm": {
     "cli": {
       "command": "ibmcloud",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "url": "https://cloud.ibm.com/docs/cli"
     },
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "onCommand:extension.ibmcloud.account.list",
     "onCommand:extension.ibmcloud.account.show",
     "onCommand:extension.ibmcloud.account.users",
-    "onCommand:extension.ibmcloud.resource.service-instances"
+    "onCommand:extension.ibmcloud.resource.service-instances",
+    "onCommand:extension.ibmcloud.plugin.install"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -279,6 +280,10 @@
       {
         "command": "extension.ibmcloud.resource.service-instances",
         "title": "ibmcloud resource service-instances"
+      },
+      {
+        "command": "extension.ibmcloud.plugin.install",
+        "title": "ibmcloud plugin install"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "onCommand:extension.ibmcloud.login.sso",
     "onCommand:extension.ibmcloud.logout",
     "onCommand:extension.ibmcloud.cli-update",
+    "onCommand:extension.ibmcloud.cli-install",
     "onCommand:extension.ibmcloud.dev.list",
     "onCommand:extension.ibmcloud.dev.build.release",
     "onCommand:extension.ibmcloud.dev.build",
@@ -114,6 +115,10 @@
       {
         "command": "extension.ibmcloud.cli-update",
         "title": "ibmcloud plugin update --all -r 'IBM Cloud' (update cli extensions)"
+      },
+      {
+        "command": "extension.ibmcloud.cli-install",
+        "title": "ibmcloud plugin install --all -r 'IBM Cloud' -f (install cli extensions)"
       },
       {
         "command": "extension.ibmcloud.dev.list",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ibm-developer",
   "displayName": "IBM Cloud CLI",
   "description": "Extension for VS Code editor to enable IBM Cloud CLI capabilities from within the editing environment.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "IBM",
   "license": "Apache 2.0 (see LICENSE.txt)",
   "bugs": {

--- a/src/commands/plugin/index.ts
+++ b/src/commands/plugin/index.ts
@@ -1,0 +1,22 @@
+/**
+* Copyright IBM Corporation 2016, 2022
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+'use strict';
+
+import { PluginInstallCommand } from './install';
+import { PluginUpdateUninstallCommand } from './updateUninstall';
+
+export { PluginInstallCommand, PluginUpdateUninstallCommand };

--- a/src/commands/plugin/install.ts
+++ b/src/commands/plugin/install.ts
@@ -1,0 +1,52 @@
+/**
+* Copyright IBM Corporation 2016, 2022
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+'use strict';
+
+import { window } from 'vscode';
+import { PromptingCommand, PromptInput } from '../../util/PromptingCommand';
+import { getInstalledPlugins, getRepoPlugins } from '../../ibmcloud/plugin';
+
+export class PluginInstallCommand extends PromptingCommand {
+
+    async execute(): Promise<any> {
+
+        this.inputs = [
+            new PromptInput('Specify a plugin to install')
+        ];
+
+        try {
+                const installedPlugins = await getInstalledPlugins();
+                const allPlugins = await getRepoPlugins();
+
+                // Provide only the plugins that have NOT been installed to user to select from
+                this.inputs[0].pickerOptions = allPlugins.filter((name:string) => installedPlugins.indexOf(name) == -1);
+        } catch (e) {
+            console.error('Could not provide picker options for plugin list');
+            console.error(e);
+        }
+
+        return super.execute();
+    }
+
+    /*
+     * display error message
+     */
+    displayError(message: string) {
+        this.output(`\nERROR: ${message}`);
+        window.showErrorMessage(message);
+    }
+}

--- a/src/commands/plugin/pluginInstall.ts
+++ b/src/commands/plugin/pluginInstall.ts
@@ -1,0 +1,48 @@
+/**
+* Copyright IBM Corporation 2016, 2022
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import { window } from 'vscode';
+import { PromptingCommand, PromptInput } from '../../util/PromptingCommand';
+import { getInstalledPlugins, getRepoPlugins } from '../../ibmcloud/plugin';
+
+export class PluginInstallCommand extends PromptingCommand {
+
+    async execute(): Promise<any> {
+
+        this.inputs = [
+            new PromptInput('Specify a plugin to install')
+        ];
+
+        try {
+                const installedPlugins = await getInstalledPlugins();
+                const allPlugins = await getRepoPlugins();
+
+                this.inputs[0].pickerOptions = allPlugins.filter((name:string) => installedPlugins.indexOf(name) == -1);
+        } catch (e) {
+            console.error('Could not provide picker options for plugin list');
+            console.error(e);
+        }
+
+        return super.execute();
+    }
+
+    /*
+     * display error message
+     */
+    displayError(message: string) {
+        this.output(`\nERROR: ${message}`);
+        window.showErrorMessage(message);
+    }
+}

--- a/src/commands/plugin/updateUninstall.ts
+++ b/src/commands/plugin/updateUninstall.ts
@@ -41,10 +41,9 @@ export class PluginUpdateUninstallCommand extends PromptingCommand {
     }
 
     /*
-     * display error message
+     * display warning message
      */
-    displayError(message: string) {
-        this.output(`\nERROR: ${message}`);
-        window.showErrorMessage(message);
+    displayWarning(message: string) {
+        window.showWarningMessage(message);
     }
 }

--- a/src/commands/plugin/updateUninstall.ts
+++ b/src/commands/plugin/updateUninstall.ts
@@ -25,7 +25,13 @@ export class PluginUpdateUninstallCommand extends PromptingCommand {
     async execute(): Promise<any> {
 
         try {
-            this.inputs[0].pickerOptions = await getInstalledPlugins();
+            const installedPlugins = await getInstalledPlugins();
+            if (installedPlugins.length === 0) {
+                this.displayWarning('No plugins are installed. Please install a plugin before trying again.');
+                return;
+            }
+
+            this.inputs[0].pickerOptions = installedPlugins;
         } catch (e) {
             console.error('Could not provide picker options for plugin list');
             console.error(e);

--- a/src/commands/plugin/updateUninstall.ts
+++ b/src/commands/plugin/updateUninstall.ts
@@ -13,23 +13,19 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 **/
-import { window } from 'vscode';
-import { PromptingCommand, PromptInput } from '../../util/PromptingCommand';
-import { getInstalledPlugins, getRepoPlugins } from '../../ibmcloud/plugin';
 
-export class PluginInstallCommand extends PromptingCommand {
+'use strict';
+
+import { window } from 'vscode';
+import { PromptingCommand } from '../../util/PromptingCommand';
+import { getInstalledPlugins } from '../../ibmcloud/plugin';
+
+export class PluginUpdateUninstallCommand extends PromptingCommand {
 
     async execute(): Promise<any> {
 
-        this.inputs = [
-            new PromptInput('Specify a plugin to install')
-        ];
-
         try {
-                const installedPlugins = await getInstalledPlugins();
-                const allPlugins = await getRepoPlugins();
-
-                this.inputs[0].pickerOptions = allPlugins.filter((name:string) => installedPlugins.indexOf(name) == -1);
+            this.inputs[0].pickerOptions = await getInstalledPlugins();
         } catch (e) {
             console.error('Could not provide picker options for plugin list');
             console.error(e);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,1 @@
+export const IBMCloud = 'IBM Cloud';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,19 @@
+/**
+ * Copyright IBM Corporation 2016, 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+'use strict';
+
 export const IBMCloud = 'IBM Cloud';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,7 @@ export function activate(context: ExtensionContext) {
     LoginManager.registerCommand(context, 'extension.ibmcloud.login.sso');
     registerCommand(context, 'extension.ibmcloud.logout', {cmd: 'ibmcloud', args: ['logout']}, outputChannel);
     registerCommand(context, 'extension.ibmcloud.cli-update', {cmd: 'ibmcloud', args: ['plugin', 'update', '--all', '-r', 'IBM Cloud']}, outputChannel);
+    registerCommand(context, 'extension.ibmcloud.cli-install', {cmd: 'ibmcloud', args: ['plugin', 'install', '--all', '-r', 'IBM Cloud', '-f']}, outputChannel);
     registerCommand(context, 'extension.ibmcloud.api', {cmd: 'ibmcloud', args: ['api']}, outputChannel);
     registerCommand(context, 'extension.ibmcloud.regions', {cmd: 'ibmcloud', args: ['regions']}, outputChannel);
     registerCommand(context, 'extension.ibmcloud.target', {cmd: 'ibmcloud', args: ['target']}, outputChannel);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import {PromptingCommand, PromptInput} from './util/PromptingCommand';
 import {SystemCommand} from './util/SystemCommand';
 import * as semver from 'semver';
 import * as packageJson from '../package.json';
+import { PluginInstallCommand } from './commands/plugin/pluginInstall';
 
 
 const outputChannel = window.createOutputChannel('IBMCloud');
@@ -102,8 +103,11 @@ export function activate(context: ExtensionContext) {
 
     // IBM Cloud RESOURCE commands *************************************
     registerCommand(context, 'extension.ibmcloud.resource.service-instances', {cmd: 'ibmcloud', args: ['resource', 'service-instances']}, outputChannel);
-}
 
+    // IBM Cloud PLUGIN commands *************************************
+    registerPromptingCommand(context, 'extension.ibmcloud.plugin.install', {cmd: 'ibmcloud', args: ['plugin', 'install']}, outputChannel, [], [], false, PluginInstallCommand);
+
+}
 
 
 /*
@@ -124,9 +128,9 @@ function registerCommand(context: ExtensionContext, key: string, opt, outputChan
 /*
  *  Helper utility to register prompting system commands
  */
-function registerPromptingCommand(context: ExtensionContext, key: string, opt, outputChannel, inputs: PromptInput[], additionalArgs: string[] = [], sanitizeOutput = false) {
+function registerPromptingCommand(context: ExtensionContext, key: string, opt, outputChannel, inputs: PromptInput[], additionalArgs: string[] = [], sanitizeOutput = false, PromptingClass = PromptingCommand) {
     const disposable = commands.registerCommand(key, () => {
-        const command = new PromptingCommand(opt.cmd, opt.args, outputChannel, inputs, additionalArgs, sanitizeOutput);
+        const command = new PromptingClass(opt.cmd, opt.args, outputChannel, inputs, additionalArgs, sanitizeOutput);
         return new Promise((resolve) => {
             resolve(executeCommand(command));
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import {PromptingCommand, PromptInput} from './util/PromptingCommand';
 import {SystemCommand} from './util/SystemCommand';
 import * as semver from 'semver';
 import * as packageJson from '../package.json';
-import { PluginInstallCommand } from './commands/plugin/pluginInstall';
+import { PluginInstallCommand, PluginUpdateUninstallCommand } from './commands/plugin';
 
 
 const outputChannel = window.createOutputChannel('IBMCloud');
@@ -106,7 +106,8 @@ export function activate(context: ExtensionContext) {
 
     // IBM Cloud PLUGIN commands *************************************
     registerPromptingCommand(context, 'extension.ibmcloud.plugin.install', {cmd: 'ibmcloud', args: ['plugin', 'install']}, outputChannel, [], [], false, PluginInstallCommand);
-
+    registerPromptingCommand(context, 'extension.ibmcloud.plugin.update', {cmd: 'ibmcloud', args: ['plugin', 'update']}, outputChannel, [new PromptInput('Specify a plugin to update')], [], false, PluginUpdateUninstallCommand);
+    registerPromptingCommand(context, 'extension.ibmcloud.plugin.uninstall', {cmd: 'ibmcloud', args: ['plugin', 'uninstall']}, outputChannel, [new PromptInput('Specify a plugin to uninstall')], [], false, PluginUpdateUninstallCommand);
 }
 
 

--- a/src/ibmcloud/plugin.ts
+++ b/src/ibmcloud/plugin.ts
@@ -1,0 +1,50 @@
+/**
+* Copyright IBM Corporation 2016, 2022
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+import { SystemCommand } from '../util/SystemCommand';
+import { IBMCloud } from '../consts';
+
+export interface RepoPlugin {
+    readonly name: string
+}
+
+export interface PluginMetadata {
+    readonly Name: string
+}
+
+// Retrieve all plugins in a given repository
+// @param {string} repoName The repository where the plugins are stored "Default: IBM Cloud" 
+export async function getRepoPlugins(repoName: string = IBMCloud): Promise<Array<string>> {
+    const allList = new SystemCommand('ibmcloud', ['plugin', 'repo-plugins', '--output', 'json']); 
+    await allList.execute();
+
+    if (allList.stderr) {
+        throw new Error(allList.stderr);
+    }
+
+    const repoPlugins: Array<RepoPlugin> = JSON.parse(allList.stdout)[repoName];
+    return repoPlugins.map((plugin:RepoPlugin) => plugin.name);
+}
+
+// Retrieve all installed plugins
+export async function getInstalledPlugins(): Promise<Array<string>> {
+    const installedList = new SystemCommand('ibmcloud', ['plugin', 'list', '--output', 'json']);
+    await installedList.execute();
+    if (installedList.stderr) {
+        throw new Error(installedList.stderr);
+    }
+    const pluginMetas: Array<PluginMetadata> = JSON.parse(installedList.stdout);
+        return pluginMetas.map((meta:PluginMetadata) => meta.Name);
+}

--- a/src/util/PromptingCommand.ts
+++ b/src/util/PromptingCommand.ts
@@ -109,7 +109,7 @@ export class PromptingCommand extends SystemCommand {
 
             let invocation;
             if (input.pickerOptions !== undefined && input.pickerOptions.length > 0) {
-                invocation = window.showQuickPick(input.pickerOptions);
+                invocation = window.showQuickPick(input.pickerOptions, { placeHolder: input.prompt });
             } else {
                 invocation = window.showInputBox({prompt: input.prompt});
             }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -254,6 +254,15 @@ describe('Extension Tests', function () {
                     assert.equal(outputChannel.withArgs(sinon.match(new RegExp(`>\\s+ibmcloud plugin install ${plugins[0]}`))).callCount, 1);
                     assert.equal(outputChannel.withArgs(sinon.match(new RegExp(`Plug-in '${plugins[0]} (?<plugin_version>.*)' was successfully installed`))).callCount, 1);
                 });
+                
+                it('should be able to install all plugins from official IBM Cloud repo', async function() {
+                    // NOTE: This is a long running command so we should increase timeout in this test case
+                    this.timeout(75000);
+                    showQuickPick.resolves(plugins);
+                    await vscode.commands.executeCommand('extension.ibmcloud.cli-install');
+                    logStub('ibmcloud plugin install --all -r IBM Cloud -f', outputChannel);
+                    assert.equal(outputChannel.withArgs(sinon.match(new RegExp(`>\\s+ibmcloud plugin install --all -r IBM Cloud -f`))).callCount, 1);
+                });
 
                 context('older version of plugin installed', function() {
                     let oldestPluginVersion: PluginVersion;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -296,7 +296,7 @@ describe('Extension Tests', function () {
                     });
                 });
 
-                it('should be able to update uninstall plugin', async function() {
+                it('should be able to uninstall plugin', async function() {
                     showQuickPick.resolves(plugins);
                     await vscode.commands.executeCommand('extension.ibmcloud.plugin.uninstall');
                     logStub('ibmcloud plugin uninstall', outputChannel);


### PR DESCRIPTION
# Context

This PR will add a few new VSCode commands from the `plugin` namespace in the IBM Cloud CLI. The following commands will be added:

- `ibmcloud plugin install`
- `ibmcloud plugin install --all`
- `ibmcloud plugin uninstall`
- `ibmcloud plugin update`

**Note**: All installed plugins will be installed from the official public **IBM Cloud** repository.

# Callouts
- If the extension fails to retrieve the plugin list to either uninstall, install or update. The user will still be able to enter the plugin name


# Steps to Test

**Note:** Is is recommended that you use a temporary directory to install plugins for testing. This will ensure the current state of your plugins are not inhibited. To do this you will need to export the `IBMCLOUD_HOME` environment (eg. `IBMCLOUD_HOME=/tmp`) in the terminal from VSCode before testing.

## Run integration tests
1. Generate API key from IBM Cloud
2. Set and export the `IBMCLOUD_API_KEY` environment variable to the key generated in step 1
3. Login into IBM Cloud using CLI
4. Change directory to the root of your local ibm-developer-vscode repo
5. Run the command `npm test`
6. Verify that all tests pass

## Test plugin install command
1. Make sure to follow the steps in the Setup section in [previous PRs](https://github.com/IBM-Cloud/ibm-developer-extension-vscode/pull/42)
2. Open the **Command Palette**
  - To enter Command Palette press Ctrl+Shift+P or F1 or navigate to View-> Command Palette
3. Type and enter in `ibmcloud login --sso` in the **Command Palette**
4. Follow the instructions to login into IBM Cloud
5. Repeat step 2 (command palette)
6. Enter the command: `ibmcloud plugin install`
7. Verify a dropdown list is shown with a list of plugins that can be installed
8. Select a plugin to install or type the plugin name in the input box then press **Enter**.
9. Verify that plugin is installed successfully by checking the **Output Channel**
10. Repeat steps 5-7 and verify that plugin installed from step 8 does not appear in the dropdown list

## Test plugin uninstall command
1. Make sure to follow the steps in **Test plugin install command** section
2. Open the **Command Palette**
3. Type and enter the command: `ibmcloud plugin uninstall`
4. Verify a dropdown list is shown the list of plugins that have been installed.
  - Verify that installed plugin from step 9 is shown
5. Select plugin from dropdown
6. Verify that plugin is successfully uninstalled by checking the **Output Channel**
7. Repeat steps 3-4 and verify that plugin that was uninstalled in step 6 does not appear in the dropdown list

### Test plugin uninstall command (no plugins installed)
1. Make sure that no plugins are installed
2. Follow the steps from 2-3 in **Test plugin uninstall command** section
3. Verify that toast message is shown that prints the message *No plugin is installed. Please install a plugin before trying again*

## Test plugin update command
1. Install an older version of plugin using the CLI
  ```
    ibmcloud plugin install code-engine 0.6.3
  ```
2. Open the Command Palette
3. Type and enter the command: `ibmcloud plugin update`
4. Verify that the plugin installed in step 1 is shown in the dropdown list
5. Type or select the plugin from step 1
6. Verify that the plugin is updated to the latest version by checking the **Output Channel**
