### PR TITLE
build: Fix updated webpack-cli complaining about require module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
 script:
   - npm run detect_secrets
   - npm run lint
+  - npm run build
 
 
 deploy:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ const config = {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     extensions: ['.ts', '.js'],
     fallback: {
-      'buffer': require.resolve('buffer/') ,
+      'buffer': require.resolve('buffer') ,
       'stream': require.resolve('stream-browserify')
       // Webpack 5 no longer polyfills Node.js core modules automatically.
       // see https://webpack.js.org/configuration/resolve/#resolvefallback


### PR DESCRIPTION
# Context

There have been recent breaking changes to webpack that is leading compilation to fail on publishing. The issue as not detected in test since this is a new update to the webpack module.

To prevent these issues from happening again I added `npm run build` to catch webpack errors in travis.

Related link: 
https://github.com/nodejs/readable-stream/issues/448

# Steps to Test
1. Run `npm run build`
2. Verify build is successful